### PR TITLE
Updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,30 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+All official releases can be found on this repository's [releases page](https://github.com/ChartBoost/chartboost-mediation-android-adapter-mintegral/releases).
+
 ### 5.16.8.41.0
+- This version of the adapter has been certified with Mintegral SDK 16.8.41.
+
+### 4.16.8.41.0
 - This version of the adapter has been certified with Mintegral SDK 16.8.41.
 
 ### 5.16.8.31.0
 - This version of the adapter has been certified with Mintegral SDK 16.8.31.
 
+### 4.16.8.31.0
+- This version of the adapter has been certified with Mintegral SDK 16.8.31.
+
 ### 5.16.8.21.0
 - This version of the adapter has been certified with Mintegral SDK 16.8.21.
 
+### 4.16.8.21.0
+- This version of the adapter has been certified with Mintegral SDK 16.8.21.
+
 ### 5.16.8.11.0
+- This version of the adapter has been certified with Mintegral SDK 16.8.11.
+
+### 4.16.8.11.0
 - This version of the adapter has been certified with Mintegral SDK 16.8.11.
 
 ### 5.16.7.91.0


### PR DESCRIPTION
Retroactively update the CHANGELOG to include a link to the official releases page on Github and with Mediation 4 releases (if necessary).