### PR TITLE
fix: allow fullscreen loads with a non-Activity context [HB-11488]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All official releases can be found on this repository's [releases page](https://
 
 ## Mediation 5
 
+### 5.16.8.61.1
+- Allow fullscreen ads to load with a non-`Activity` context, e.g. from the fullscreen ad queue. Banner ads still require an `Activity` context.
+
 ### 5.16.8.61.0
 - This version of the adapter has been certified with Mintegral SDK 16.8.61.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All official releases can be found on this repository's [releases page](https://
 ## Mediation 5
 
 ### 5.16.8.61.1
+- This version of the adapter has been certified with Mintegral SDK 16.8.61.
 - Allow fullscreen ads to load with a non-`Activity` context, e.g. from the fullscreen ad queue. Banner ads still require an `Activity` context.
 
 ### 5.16.8.61.0

--- a/MintegralAdapter/build.gradle.kts
+++ b/MintegralAdapter/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         minSdk = 21
         targetSdk = 34
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.16.8.61.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.16.8.61.1"
         buildConfigField("String", "CHARTBOOST_MEDIATION_MINTEGRAL_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/MintegralAdapter/src/main/java/com/chartboost/mediation/mintegraladapter/MintegralAdapter.kt
+++ b/MintegralAdapter/src/main/java/com/chartboost/mediation/mintegraladapter/MintegralAdapter.kt
@@ -216,7 +216,7 @@ class MintegralAdapter : PartnerAdapter {
         // key names for the Mintegral unit ID.
         val unitId = request.partnerSettings["mintegral_unit_id"] as? String ?: request.partnerSettings["unit_id"] as? String ?: ""
 
-        if (!canLoadAd(context, request.partnerPlacement, unitId)) {
+        if (!canLoadAd(context, request.format, request.partnerPlacement, unitId)) {
             return Result.failure(ChartboostMediationAdException(ChartboostMediationError.LoadError.InvalidPartnerPlacement))
         }
 
@@ -393,6 +393,7 @@ class MintegralAdapter : PartnerAdapter {
      * Check whether ads can be loaded.
      *
      * @param context The current [Context].
+     * @param format The ad format to load.
      * @param partnerPlacement The placement for the ad.
      * @param partnerUnitId The unit ID for the ad.
      *
@@ -400,6 +401,7 @@ class MintegralAdapter : PartnerAdapter {
      */
     private fun canLoadAd(
         context: Context,
+        format: PartnerAdFormat,
         partnerPlacement: String,
         partnerUnitId: String,
     ): Boolean {
@@ -408,8 +410,11 @@ class MintegralAdapter : PartnerAdapter {
                 PartnerLogController.log(LOAD_FAILED, "The SDK is not initialized.")
                 false
             }
-            context !is Activity -> {
-                PartnerLogController.log(LOAD_FAILED, "Context must be an Activity.")
+            // Mintegral's fullscreen handlers take a plain Context (verified against MBridge
+            // 16.8.61), so fullscreen loads from the ad queue's application context are allowed.
+            // Banners stay Activity-bound so MBBannerView inherits the Activity theme.
+            format == PartnerAdFormats.BANNER && context !is Activity -> {
+                PartnerLogController.log(LOAD_FAILED, "Banner ads require an Activity context.")
                 false
             }
             partnerPlacement.isEmpty() || partnerUnitId.isEmpty() -> {


### PR DESCRIPTION
## Summary
Part of [HB-11488]: the Mediation fullscreen ad queue now retains only the application context, so the adapter's self-imposed Activity requirement blocked queued fullscreen loads.

## Changes
- `canLoadAd()` now enforces the Activity requirement for banners only, Mintegral's fullscreen handlers take a plain `Context` (verified against MBridge 16.8.61). Banners keep it so `MBBannerView` inherits the Activity theme.
- Version bump `5.16.8.61.0` → `5.16.8.61.1` + CHANGELOG entry.
- Note for reviewers: fullscreen show-from-app-context should get a Canary smoke test (load via queue → show) before merge.

Companion PRs: main repo (queue fix) and the ironSource adapter.

[HB-11488]: https://loopme.atlassian.net/browse/HB-11488